### PR TITLE
Permissions are not set properly

### DIFF
--- a/lib/FileSystemCache.php
+++ b/lib/FileSystemCache.php
@@ -193,7 +193,7 @@ class FileSystemCache {
 			//make sure the directory exists and is writable
 			$directory = dirname($filename);
 			if(!file_exists($directory)) {
-				if(!mkdir($directory,777,true)) {
+				if(!mkdir($directory,0777,true)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Automatic folder creation didn't work properly on my Mac. It seems that permissions weren't set properly.
